### PR TITLE
Add a blackhole CPU feature on Backend

### DIFF
--- a/src/main/java/http2/bench/Utils.java
+++ b/src/main/java/http2/bench/Utils.java
@@ -1,11 +1,17 @@
 package http2.bench;
 
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadMXBean;
 import java.math.BigInteger;
+import java.util.concurrent.ThreadLocalRandom;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
 public class Utils {
+  public static long res = 0; // value sink
+  public static long ONE_MILLI_IN_NANO = 1000000;
+  public static long ONE_MICRO_IN_NANO = 1000;
 
   public static BigInteger parseSize(String s) {
     long scale = 1;
@@ -29,4 +35,42 @@ public class Utils {
     }
     return new BigInteger(s).multiply(BigInteger.valueOf(scale));
   }
+
+  /* the purpose of this method is to consume pure CPU without
+   * additional resources (memory, io).
+   * We may need to simulate milliseconds of cpu usage so
+   * base calculation is somewhat complex to avoid too many iterations
+   */
+  public static void blackholeCpu(long iterations) {
+    long result = 0;
+    for (int i=0; i < iterations; i++) {
+      int next = (ThreadLocalRandom.current().nextInt() % 1019) / 17;
+      result = result ^ (Math.round(Math.pow(next,3)) % 251);
+    }
+    res += result;
+  }
+
+  /* Estimates the number of iterations of blackholeCpu needed to
+   * spend one milliseconds of CPU time
+   */
+  public static long calibrateBlackhole() {
+    ThreadMXBean threadBean = ManagementFactory.getThreadMXBean();
+    // Make the blackholeCpu method hot, to force C2 optimization
+    for (int i=0; i < 50000; i++) {
+      Utils.blackholeCpu(100);
+    }
+    // find the number of iterations needed to spend more than 1 milli
+    // of cpu time
+    final long[] iters = {1000,5000,10000,20000,50000,100000};
+    long timing = 0;
+    int i=-1;
+    while (timing < ONE_MILLI_IN_NANO && ++i < iters.length) {
+      long start_cpu = threadBean.getCurrentThreadCpuTime();
+      Utils.blackholeCpu(iters[i]);
+      timing=threadBean.getCurrentThreadCpuTime()-start_cpu;
+    }
+    // estimate the number of iterations for 1 milli
+    return Math.round(Math.ceil((ONE_MILLI_IN_NANO*1.0/timing)*iters[i]));
+  }
+
 }


### PR DESCRIPTION
Utils.blackholeCpu() can be used to waste cpu time based on a number of iterations
Utils.calibrateBlackhole() estimates the number of iterations needed to spend a full millisecond

A new `--cpu` switch on the backend command let the user specify the amount of cpu microseconds they want to waste when processing a query. No coherency check is enforced but using cpu time bigger than request latency probably doesn't make sense.

The blackhole function time estimate has a variance 5% when benched with JMH:

```
Benchmark                    (iterations)  Mode  Cnt    Score    Error  Units
MyBenchmark.customBlackHole            10  avgt   20    0,812 ±  0,030  us/op
MyBenchmark.customBlackHole           100  avgt   20    8,143 ±  0,162  us/op
MyBenchmark.customBlackHole          1000  avgt   20   81,035 ±  1,680  us/op
MyBenchmark.customBlackHole         10000  avgt   20  785,463 ± 19,415  us/op
```